### PR TITLE
Add create_hours_dist.sh

### DIFF
--- a/bin/create_hours_dist.sh
+++ b/bin/create_hours_dist.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+wrkDir=$1
+tmpDir=$(mktemp -d)
+
+touch "$tmpDir"/hours.txt
+
+cat "$wrkDir"/*/failed_login_data.txt | awk 'match($0, /[a-zA-z]+ [0-9]+ ([0-9]+) /, groups) {print groups[1]}' >> "$tmpDir"/hours.txt
+
+touch "$tmpDir"/countHours.txt
+
+sort "$tmpDir"/hours.txt | uniq -c | awk 'match($0, /([0-9]+) ([0-9]+)/, groups) {print "data.addRow([\x27" groups[2] "\x27, " groups[1] "]);"}' >> "$tmpDir"/countHours.txt
+
+bin/wrap_contents.sh "$tmpDir"/countHours.txt html_components/hours_dist "$wrkDir"/hours_dist.html


### PR DESCRIPTION
This commit adds create_hours_dist.sh, which works like create_usernames_dist.sh, but instead of taking usernames from the log files, it instead takes the hours from the log files.

Co-authored-by: Erik Rauer rauer007@morris.umn.edu